### PR TITLE
Enhance text transcript formatting with word-level timestamps

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8050:8000"
     environment:
       - API_KEY=${API_KEY:-}  # Optional: uses API_KEY value if defined, empty otherwise
     volumes:


### PR DESCRIPTION
Hi !

It could be interesting to add timecode to the `/transcript` endpoint by adding word-level timestamp support for the TEXT format output.
Each word in the transcript is now accompanied by its approximate timestamp in the format `[MM:SS.mmm]`.

## Features
- Splits transcript segments into individual words
- Calculates approximate timestamps for each word based on segment duration
- Formats timestamps in a readable [MM:SS.mmm] format
- Maintains backward compatibility with existing formats (JSON, WEBVTT, SRT)

## Example Output
```text
[00:00.100] Hello
[00:00.300] and
[00:00.500] welcome
[00:00.700] to
[00:00.900] this
[00:01.100] video
```

## Technical Notes
- Timestamps are approximated by evenly distributing segment duration across words
- No changes to the API interface - feature is automatically enabled for TEXT format
- Minimal performance impact as calculations are lightweight

## Usage
Request the transcript with format=text: